### PR TITLE
allow bypass of hardcoded credentials for testing script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ docs/vsn-sunspec-point-mapping-backup-*.xlsx
 docs/vsn-sunspec-point-mapping-*-fixed.xlsx
 docs/vsn-sunspec-point-mapping-*.xlsx
 !docs/vsn-sunspec-point-mapping.xlsx
+venv/


### PR DESCRIPTION
Allows easier testing by passing credentials unique for each installation.
Example `python test_vsn_client.py 192.168.1.2 --username admin --password 123isBestJK`