### PR TITLE
fix: remove last_updated sensor attribute to stop recorder DB growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.1] - Unreleased
+## [1.5.2] - Unreleased
+
+### Bug Fixes
+
+- **Remove `last_updated` sensor attribute to stop recorder database growth** (Fixes #56) -
+  Every sensor exposed a `last_updated` attribute sourced from the coordinator timestamp,
+  which changed on every poll. This defeated the recorder's `state_attributes`
+  deduplication, forcing a new attributes row per state write for every entity (368 MB
+  `state_attributes` table in the reporter's setup). The attribute is now removed; Home
+  Assistant already tracks update timing natively via the core
+  `last_changed`/`last_updated`/`last_reported` state fields. Thanks to @fabioquarantini
+  for the detailed report.
+
+### Breaking Changes
+
+- The `last_updated` attribute is no longer present on integration sensors. Automations or
+  templates reading `state_attr('sensor.x', 'last_updated')` should use the core state
+  property `states.sensor.x.last_updated` (or `last_changed`) instead.
+
+## [1.5.1] - 2026-03-30
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -760,6 +760,7 @@ standalone test script.**
 - Result: ✅ Normalized JSON now shows correct kWh values
 
 **Files Modified**:
+
 - `custom_components/.../sensor.py` (attribute validation + exception handling)
 - `scripts/vsn_client.py` (mapping URL + energy conversion)
 - Version bump to v1.1.11
@@ -792,6 +793,7 @@ works properly.
 - Result: Energy sensors now correctly display in kWh after fresh installation
 
 **Files Modified**:
+
 - `custom_components/.../normalizer.py` (use local variable pattern)
 - Version bump to v1.1.10
 
@@ -830,6 +832,7 @@ works properly.
 - Result: SysTime loads without errors and displays formatted date/time string
 
 **Files Modified**:
+
 - `scripts/vsn-mapping-generator/generate_mapping.py` (3 changes: energy units, TIMESTAMP_SENSORS, SysTime precision)
 - Regenerated all mapping files (Excel + 3 JSON copies)
 - Version bump to v1.1.9
@@ -881,6 +884,7 @@ works properly.
 - Result: ALL energy sensors now convert correctly and display in kWh with proper values
 
 **Files Modified**:
+
 - `scripts/vsn-mapping-generator/generate_mapping.py` (4 changes: state sensor precision, SysTime device_class)
 - `custom_components/.../sensor.py` (defensive precision check)
 - `custom_components/.../normalizer.py` (device_class-based energy conversion)
@@ -932,6 +936,7 @@ values (critical data error).
 - Updated current version to v1.1.7
 
 **Benefits:**
+
 - Generator is now single source of truth for ALL sensor metadata
 - All fixes from v1.1.3-v1.1.7 permanently codified in generator
 - No risk of manual edits being lost during regeneration
@@ -977,6 +982,7 @@ values (critical data error).
 - Commit: [df7557f](https://github.com/alexdelprete/ha-abb-fimer-pvi-vsn-rest/commit/df7557f)
 
 **Affected Sensors** (now display correctly without decimals):
+
 - Chc → 82277504 (no decimals, no unit)
 - Dhc → 183048368 (no decimals, no unit)
 - CycleNum → 707 (no decimals, no unit)
@@ -1002,6 +1008,7 @@ This is a known limitation already documented in sensor.py for system_load.
 - Commit: [12d0ea6](https://github.com/alexdelprete/ha-abb-fimer-pvi-vsn-rest/commit/12d0ea6)
 
 **Affected Sensors** (now display correctly with 0 decimals):
+
 - Chc (Battery charge cycles counter)
 - Dhc (Battery discharge cycles counter)
 - CycleNum (Count - Battery Cycles)
@@ -1035,6 +1042,7 @@ This is a known limitation already documented in sensor.py for system_load.
 - Commit: [86c47dc](https://github.com/alexdelprete/ha-abb-fimer-pvi-vsn-rest/commit/86c47dc)
 
 **Sensors Fixed by Type**:
+
 - Current (5): Iba, Iin1, Iin2, IleakInv, IleakDC → device_class=current, unit=A, precision=2
 - Voltage (4): Vba, ShU, Vin1, Vin2 → device_class=voltage, unit=V, precision=1
 - Power (5): Pba, MeterPgrid_L1/L2/L3 → device_class=power, unit=W, precision=0
@@ -1046,12 +1054,14 @@ This is a known limitation already documented in sensor.py for system_load.
 ### 🛠️ Tools Added
 
 **Mapping Maintenance Scripts**:
+
 - `scripts/update_mapping_metadata.py` - Systematic metadata updates
 - `scripts/generate_mapping_analysis.py` - Generate XLSX analysis files
 
 ### 📚 Documentation
 
 **README Improvements**:
+
 - Updated shields/badges to match legacy integration style (reference-style, for-the-badge)
 - Added HACS quick installation badge
 - Added Coffee section

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ described below:
 | **Recovery script** | (none) | Script to execute when failures threshold is reached (e.g., `script.restart_router`) |
 
 **Runtime vs Startup Notifications:**
+
 - **Runtime**: Monitors failures during normal operation after HA is running
 - **Startup**: Monitors failures when HA starts/restarts and can't connect to the device
 

--- a/custom_components/abb_fimer_pvi_vsn_rest/sensor.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/sensor.py
@@ -717,9 +717,11 @@ class VSNSensor(CoordinatorEntity[ABBFimerPVIVSNRestCoordinator], SensorEntity):
             "category": point_data.get("category", ""),
         }
 
-        # Add timestamp if available
-        if timestamp := device_data.get("timestamp"):
-            attributes["last_updated"] = timestamp
+        # Note: a "last_updated" attribute is intentionally NOT added here.
+        # The coordinator timestamp changes on every poll, which defeats the
+        # recorder's state_attributes deduplication and bloats the database
+        # (see issue #56). Home Assistant already tracks update timing natively
+        # via the core last_changed/last_updated/last_reported state fields.
 
         # Add raw state code if state translation is active
         if self._state_mapping:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1506,12 +1506,17 @@ class TestVSNSensorStateMapping:
 class TestVSNSensorExtraStateAttributesEdgeCases:
     """Additional tests for extra_state_attributes edge cases."""
 
-    def test_extra_state_attributes_with_timestamp(
+    def test_extra_state_attributes_omits_last_updated(
         self,
         mock_coordinator: MagicMock,
         mock_sensor_config_entry: MagicMock,
     ) -> None:
-        """Test extra state attributes include timestamp when available."""
+        """Test extra state attributes do not include a last_updated timestamp.
+
+        The coordinator timestamp changes on every poll; exposing it as an
+        attribute defeats the recorder's state_attributes deduplication and
+        bloats the database (issue #56). HA tracks update timing natively.
+        """
         point_data = {
             "value": 5000,
             "ha_display_name": "Power AC",
@@ -1536,7 +1541,7 @@ class TestVSNSensorExtraStateAttributesEdgeCases:
         )
 
         attrs = sensor.extra_state_attributes
-        assert attrs["last_updated"] == "2025-01-01T12:00:00"
+        assert "last_updated" not in attrs
 
     def test_extra_state_attributes_with_state_mapping(
         self,


### PR DESCRIPTION
## Summary

Fixes #56.

Every sensor exposed a `last_updated` attribute in `extra_state_attributes`, sourced from the coordinator timestamp (`device_data["timestamp"]`). That value changes on every poll cycle (`scan_interval`, default 60 s).

Home Assistant's recorder deduplicates attribute rows by hashing the serialized attributes JSON. Because `last_updated` was the only changing key — every other attribute is static per entity — the recorder could never reuse a `state_attributes` row, storing a near-full copy of the metadata JSON on every state write for every entity.

In the reporter's setup (66 entities, 60 s polling, ~10 days): ~620,070 distinct attribute rows, a 368 MB `state_attributes` table, ~99.3% of which belonged to this integration.

## Changes

- **`sensor.py`** — Removed the `last_updated` attribute from `extra_state_attributes`. All remaining attributes are static per entity, so the recorder collapses to ~1 `state_attributes` row per entity.
- **`tests/test_sensor.py`** — Updated the test to assert `last_updated` is absent.
- **`CHANGELOG.md`** — Added a `[1.5.2]` entry with the fix and a breaking-change note.

## Why this is safe / correct

Home Assistant already tracks update timing natively for every entity via the core state fields `last_changed`, `last_updated`, and `last_reported` — available through the state model, UI, templates, and API. The custom attribute was redundant and additionally **shadowed the core `last_updated` state property name**, which is confusing in templates/API.

## Breaking change

The `last_updated` attribute is no longer present on integration sensors. Automations or templates reading `state_attr('sensor.x', 'last_updated')` should use the core state property `states.sensor.x.last_updated` (or `last_changed`) instead.

Thanks to @fabioquarantini for the detailed report and analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)