### PR TITLE
fix(vsn300): digest nc/cnonce firmware constants + charset-tolerant JSON decoding

### DIFF
--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/auth.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/auth.py
@@ -14,9 +14,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
-import os
 import re
-import time
 
 import aiohttp
 
@@ -127,11 +125,10 @@ def build_digest_header(
 
     # For VSN300, we typically don't use qop, but handle it if present
     if qop:
-        nc = "00000001"
-        # Generate cnonce like stdlib: H(nonce:time:random)
-
-        cnonce_input = f"{nonce}:{time.time()}:{os.urandom(8).hex()}"
-        cnonce = hashlib.md5(cnonce_input.encode()).hexdigest()[:16]  # noqa: S324
+        # VSN300 firmware (auth-filter.js) validates against these EXACT constants.
+        # Any other nc/cnonce -> HTTP 401. See issue #68.
+        nc = "00000002"
+        cnonce = "ddf4bfcaf87acba9"
         response = calculate_digest_response(
             username, password, realm, nonce, method, uri, qop, nc, cnonce
         )

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/auth.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/auth.py
@@ -418,7 +418,7 @@ async def detect_vsn_model(
                 )
 
                 try:
-                    status_data = await response.json()
+                    status_data = await response.json(encoding="latin-1", content_type=None)
                     model = _detect_model_from_status(status_data)
                 except Exception as parse_err:
                     _LOGGER.error(

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/auth.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/auth.py
@@ -25,7 +25,7 @@ from .exceptions import (
     VSNDetectionError,
     VSNUnsupportedDeviceError,
 )
-from .utils import check_socket_connection
+from .utils import check_socket_connection, read_json_lenient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -418,7 +418,7 @@ async def detect_vsn_model(
                 )
 
                 try:
-                    status_data = await response.json(encoding="latin-1", content_type=None)
+                    status_data = await read_json_lenient(response)
                     model = _detect_model_from_status(status_data)
                 except Exception as parse_err:
                     _LOGGER.error(

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/client.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/client.py
@@ -169,7 +169,7 @@ class ABBFimerVSNRestClient:
                 )
 
                 if response.status == 200:
-                    data = await response.json()
+                    data = await response.json(encoding="latin-1", content_type=None)
                     # Count total points across all devices
                     total_points = sum(
                         len(device_data.get("points", [])) for device_data in data.values()

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/client.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/client.py
@@ -11,7 +11,7 @@ from .auth import detect_vsn_model, get_vsn300_digest_header, get_vsn700_basic_a
 from .constants import ENDPOINT_LIVEDATA
 from .exceptions import VSNAuthenticationError, VSNConnectionError
 from .normalizer import VSNDataNormalizer
-from .utils import check_socket_connection
+from .utils import check_socket_connection, read_json_lenient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -169,7 +169,7 @@ class ABBFimerVSNRestClient:
                 )
 
                 if response.status == 200:
-                    data = await response.json(encoding="latin-1", content_type=None)
+                    data = await read_json_lenient(response)
                     # Count total points across all devices
                     total_points = sum(
                         len(device_data.get("points", [])) for device_data in data.values()

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/discovery.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/discovery.py
@@ -16,7 +16,7 @@ import aiohttp
 from .auth import detect_vsn_model, get_vsn300_digest_header, get_vsn700_basic_auth
 from .constants import ENDPOINT_LIVEDATA, ENDPOINT_STATUS
 from .exceptions import VSNConnectionError
-from .utils import check_socket_connection
+from .utils import check_socket_connection, read_json_lenient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -205,7 +205,7 @@ async def _fetch_status(
             )
 
             if response.status == 200:
-                data = await response.json(encoding="latin-1", content_type=None)
+                data = await read_json_lenient(response)
                 _LOGGER.debug(
                     "[Discovery Status] Successfully fetched status data (%d bytes)",
                     len(str(data)),
@@ -297,7 +297,7 @@ async def _fetch_livedata(
             )
 
             if response.status == 200:
-                data = await response.json(encoding="latin-1", content_type=None)
+                data = await read_json_lenient(response)
                 _LOGGER.debug(
                     "[Discovery Livedata] Successfully fetched livedata: %d devices, %d bytes",
                     len(data),

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/discovery.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/discovery.py
@@ -205,7 +205,7 @@ async def _fetch_status(
             )
 
             if response.status == 200:
-                data = await response.json()
+                data = await response.json(encoding="latin-1", content_type=None)
                 _LOGGER.debug(
                     "[Discovery Status] Successfully fetched status data (%d bytes)",
                     len(str(data)),
@@ -297,7 +297,7 @@ async def _fetch_livedata(
             )
 
             if response.status == 200:
-                data = await response.json()
+                data = await response.json(encoding="latin-1", content_type=None)
                 _LOGGER.debug(
                     "[Discovery Livedata] Successfully fetched livedata: %d devices, %d bytes",
                     len(data),

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/utils.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/utils.py
@@ -1,13 +1,40 @@
 """Utility functions for VSN REST client."""
 
 import asyncio
+import json
 import logging
 import socket
+from typing import Any
 from urllib.parse import urlparse
+
+import aiohttp
 
 from .exceptions import VSNConnectionError
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def read_json_lenient(response: aiohttp.ClientResponse) -> Any:
+    """Parse JSON tolerating the firmware's wrong/missing charset declarations.
+
+    VSN300 bodies may contain non-UTF-8 bytes (e.g. accented characters in
+    user-entered labels) while the Content-Type claims utf-8 or omits charset.
+    Try UTF-8 first (byte-identical for all ASCII payloads), fall back to
+    latin-1 (never fails) for legacy single-byte content. See issue #68.
+
+    Args:
+        response: The aiohttp response whose body to decode and parse.
+
+    Returns:
+        The parsed JSON value.
+
+    """
+    raw = await response.read()
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        text = raw.decode("latin-1")
+    return json.loads(text)
 
 
 async def check_socket_connection(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -175,6 +175,23 @@ class TestBuildDigestHeader:
 
         assert 'opaque="xyz789"' in result
 
+    def test_build_header_uses_vsn300_firmware_constants(self) -> None:
+        """VSN300 firmware only accepts the hardcoded nc/cnonce constants."""
+        challenge_params = {
+            "realm": "registered_user@power-one.com",
+            "nonce": "abc123",
+            "qop": "auth",
+        }
+        result = build_digest_header(
+            username="guest",
+            password="password",  # noqa: S106
+            challenge_params=challenge_params,
+            method="GET",
+            uri="/v1/status",
+        )
+        assert "nc=00000002" in result
+        assert 'cnonce="ddf4bfcaf87acba9"' in result
+
 
 class TestGetVSN700BasicAuth:
     """Tests for get_vsn700_basic_auth function."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -452,12 +453,14 @@ class TestDetectVSNModel:
         mock_response = MagicMock()
         mock_response.status = 200
         mock_response.headers = {}
-        mock_response.json = AsyncMock(
-            return_value={
-                "keys": {
-                    "logger.board_model": {"value": "WIFI LOGGER CARD"},
+        mock_response.read = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "keys": {
+                        "logger.board_model": {"value": "WIFI LOGGER CARD"},
+                    }
                 }
-            }
+            ).encode()
         )
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=None)
@@ -600,7 +603,9 @@ class TestDetectVSNModel:
         mock_response = MagicMock()
         mock_response.status = 200
         mock_response.headers = {}
-        mock_response.json = AsyncMock(side_effect=ValueError("Invalid JSON"))
+        # read_json_lenient reads raw bytes then json.loads(); invalid JSON bytes
+        # must surface as a parse error -> VSNDetectionError.
+        mock_response.read = AsyncMock(return_value=b"not valid json {{{")
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=None)
 
@@ -653,12 +658,14 @@ class TestDetectVSNModel:
         mock_response = MagicMock()
         mock_response.status = 200
         mock_response.headers = {}
-        mock_response.json = AsyncMock(
-            return_value={
-                "keys": {
-                    "logger.loggerId": {"value": "ac:1f:0f:b0:50:b5"},
+        mock_response.read = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "keys": {
+                        "logger.loggerId": {"value": "ac:1f:0f:b0:50:b5"},
+                    }
                 }
-            }
+            ).encode()
         )
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=None)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -171,7 +172,7 @@ class TestABBFimerVSNRestClientGetLivedata:
 
         mock_response = AsyncMock()
         mock_response.status = 200
-        mock_response.json = AsyncMock(return_value=sample_livedata)
+        mock_response.read = AsyncMock(return_value=json.dumps(sample_livedata).encode())
         mock_response.headers = {}
 
         mock_session.get = MagicMock(
@@ -206,7 +207,7 @@ class TestABBFimerVSNRestClientGetLivedata:
 
         mock_response = AsyncMock()
         mock_response.status = 200
-        mock_response.json = AsyncMock(return_value=sample_livedata)
+        mock_response.read = AsyncMock(return_value=json.dumps(sample_livedata).encode())
         mock_response.headers = {}
 
         mock_session.get = MagicMock(
@@ -235,7 +236,7 @@ class TestABBFimerVSNRestClientGetLivedata:
 
         mock_response = AsyncMock()
         mock_response.status = 200
-        mock_response.json = AsyncMock(return_value=sample_livedata)
+        mock_response.read = AsyncMock(return_value=json.dumps(sample_livedata).encode())
         mock_response.headers = {}
 
         mock_session.get = MagicMock(
@@ -342,7 +343,7 @@ class TestABBFimerVSNRestClientGetLivedata:
         sample_data: dict[str, Any] = {"device": {"points": []}}
         mock_response = AsyncMock()
         mock_response.status = 200
-        mock_response.json = AsyncMock(return_value=sample_data)
+        mock_response.read = AsyncMock(return_value=json.dumps(sample_data).encode())
         mock_response.headers = {}
 
         mock_session.get = MagicMock(
@@ -654,24 +655,20 @@ class TestDeviceTypeInjection:
         assert client._device_type_map == {}
 
 
-async def test_get_livedata_decodes_latin1_body() -> None:
-    """VSN serves ISO-8859-1 JSON with application/json; must not UnicodeDecodeError."""
-    from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.client import (
-        ABBFimerVSNRestClient,
-    )
+async def test_get_livedata_uses_lenient_json_decode() -> None:
+    """get_livedata decodes the body via read_json_lenient (issue #68).
 
-    # 0xB4 is the acute-accent byte that crashes utf-8 json()
-    payload = {"ser4:X": {"points": [{"name": "lbl", "value": "caf´"}]}}
+    The charset-tolerant parsing itself is covered by tests/test_utils.py
+    (TestReadJsonLenient); here we confirm get_livedata routes through it and
+    returns the parsed payload.
+    """
+    # Raw ISO-8859-1 body with a lone 0xB4 that crashes utf-8 json().
+    raw = b'{"ser4:X": {"points": [{"name": "lbl", "value": "caf\xb4"}]}}'
+    expected = {"ser4:X": {"points": [{"name": "lbl", "value": "caf\xb4"}]}}
 
     mock_resp = MagicMock()
     mock_resp.status = 200
-
-    async def _json(encoding=None, content_type=None):
-        assert encoding == "latin-1"
-        assert content_type is None
-        return payload
-
-    mock_resp.json = _json
+    mock_resp.read = AsyncMock(return_value=raw)
     mock_ctx = MagicMock()
     mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_ctx.__aexit__ = AsyncMock(return_value=False)
@@ -687,4 +684,4 @@ async def test_get_livedata_decodes_latin1_body() -> None:
         new=AsyncMock(),
     ):
         data = await client.get_livedata()
-    assert data == payload
+    assert data == expected

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -652,3 +652,39 @@ class TestDeviceTypeInjection:
         client._ensure_device_type_map()
 
         assert client._device_type_map == {}
+
+
+async def test_get_livedata_decodes_latin1_body() -> None:
+    """VSN serves ISO-8859-1 JSON with application/json; must not UnicodeDecodeError."""
+    from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.client import (
+        ABBFimerVSNRestClient,
+    )
+
+    # 0xB4 is the acute-accent byte that crashes utf-8 json()
+    payload = {"ser4:X": {"points": [{"name": "lbl", "value": "caf´"}]}}
+
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+
+    async def _json(encoding=None, content_type=None):
+        assert encoding == "latin-1"
+        assert content_type is None
+        return payload
+
+    mock_resp.json = _json
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    session = MagicMock()
+    session.get = MagicMock(return_value=mock_ctx)
+
+    client = ABBFimerVSNRestClient(
+        session=session, base_url="http://host", vsn_model="VSN700", requires_auth=False
+    )
+    with patch(
+        "custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.client.check_socket_connection",
+        new=AsyncMock(),
+    ):
+        data = await client.get_livedata()
+    assert data == payload

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -325,7 +326,7 @@ class TestFetchStatus:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.headers = {}
-        mock_response.json = AsyncMock(return_value=status_data)
+        mock_response.read = AsyncMock(return_value=json.dumps(status_data).encode())
 
         mock_session.get = MagicMock(
             return_value=AsyncMock(
@@ -358,7 +359,7 @@ class TestFetchStatus:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.headers = {}
-        mock_response.json = AsyncMock(return_value=status_data)
+        mock_response.read = AsyncMock(return_value=json.dumps(status_data).encode())
 
         mock_session.get = MagicMock(
             return_value=AsyncMock(
@@ -390,7 +391,7 @@ class TestFetchStatus:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.headers = {}
-        mock_response.json = AsyncMock(return_value=status_data)
+        mock_response.read = AsyncMock(return_value=json.dumps(status_data).encode())
 
         mock_session.get = MagicMock(
             return_value=AsyncMock(
@@ -475,7 +476,7 @@ class TestFetchLivedata:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.headers = {}
-        mock_response.json = AsyncMock(return_value=livedata)
+        mock_response.read = AsyncMock(return_value=json.dumps(livedata).encode())
 
         mock_session.get = MagicMock(
             return_value=AsyncMock(
@@ -508,7 +509,7 @@ class TestFetchLivedata:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.headers = {}
-        mock_response.json = AsyncMock(return_value=livedata)
+        mock_response.read = AsyncMock(return_value=json.dumps(livedata).encode())
 
         mock_session.get = MagicMock(
             return_value=AsyncMock(
@@ -540,7 +541,7 @@ class TestFetchLivedata:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.headers = {}
-        mock_response.json = AsyncMock(return_value=livedata)
+        mock_response.read = AsyncMock(return_value=json.dumps(livedata).encode())
 
         mock_session.get = MagicMock(
             return_value=AsyncMock(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -11,6 +11,7 @@ from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.exceptio
 )
 from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.utils import (
     check_socket_connection,
+    read_json_lenient,
 )
 
 
@@ -141,3 +142,42 @@ class TestCheckSocketConnection:
             # Socket create_connection signature: (address, timeout=...)
             # Check if timeout is in the call
             assert mock_create.call_args[0][1] == 10 or "timeout" in str(mock_create.call_args)
+
+
+class TestReadJsonLenient:
+    """Tests for read_json_lenient — UTF-8 first, latin-1 fallback (issue #68)."""
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_latin1_on_non_utf8_byte(self) -> None:
+        """A body with 0xB4 (Latin-1 acute accent) parses via the latin-1 fallback."""
+        # 0xB4 is a lone high byte that is invalid UTF-8; valid in Latin-1 (´).
+        raw = b'{"label": "caf\xb4"}'
+        response = MagicMock()
+        response.read = AsyncMock(return_value=raw)
+
+        result = await read_json_lenient(response)
+
+        assert result == {"label": "caf\xb4"}
+
+    @pytest.mark.asyncio
+    async def test_utf8_wins_for_multibyte_body(self) -> None:
+        """A genuine multibyte UTF-8 body decodes as UTF-8, not mojibake latin-1."""
+        # "café" with é as the two-byte UTF-8 sequence 0xC3 0xA9.
+        raw = '{"label": "café"}'.encode()
+        response = MagicMock()
+        response.read = AsyncMock(return_value=raw)
+
+        result = await read_json_lenient(response)
+
+        assert result == {"label": "café"}
+
+    @pytest.mark.asyncio
+    async def test_ascii_body_parses(self) -> None:
+        """A plain ASCII body (the common case) parses unchanged."""
+        raw = b'{"m101_1_W": 1737.9, "units": "kW"}'
+        response = MagicMock()
+        response.read = AsyncMock(return_value=raw)
+
+        result = await read_json_lenient(response)
+
+        assert result == {"m101_1_W": 1737.9, "units": "kW"}


### PR DESCRIPTION
Fixes items **1 and 2** of #68 (VSN300 config-flow failure). Item 3 (`/v1/livedata` on fw 2.0.0) was addressed separately: fw 2.0.0 is not supported (vendor regression, fixed in fw 2.0.1 — see #68), so the feeds-fallback PR #70 was closed.

## 1. Digest `nc`/`cnonce` must be firmware constants

VSN300 firmware's `auth-filter.js` validates the digest against the **exact** constants `nc=00000002`, `cnonce=ddf4bfcaf87acba9`. The previous `nc=00000001` + random cnonce → HTTP 401 on every authenticated request on fw 2.0.x. Reproduced from a clean `http.client` script (not HA-specific), and verified 200-vs-401 against real hardware. Independently verified safe on fw 1.9.2, which validates RFC-style and accepts the constants as well — they're what the firmware's own web UI sends, so every firmware must accept them.

## 2. Non-UTF-8 JSON

The datalogger can serve ISO-8859-1 bodies (e.g. accented characters in user-entered labels) while the `Content-Type` claims utf-8 or omits the charset; aiohttp's default `response.json()` raises `UnicodeDecodeError` on bytes like `0xB4`. Fixed with a shared `read_json_lenient()` helper in `utils.py`: read raw bytes, try UTF-8 first (byte-identical for all ASCII payloads), fall back to latin-1 (never fails) on decode error. All four call sites (auth, client, discovery ×2) route through it.

## Tests

- New: `build_digest_header` asserts the firmware constants.
- New: `TestReadJsonLenient` unit tests — latin-1 fallback on a lone `0xB4` byte, genuine multibyte UTF-8 decodes as UTF-8 (no mojibake), plain ASCII passthrough.
- New: `get_livedata` end-to-end with a raw non-UTF-8 body.
- Existing auth/client/discovery tests migrated from mocking `.json()` to mocking `.read()` with encoded bytes.

Verified against VSN300 firmware 2.0.0 hardware; digest constants also verified live against fw 1.9.2.