### PR TITLE
feat(vsn300): /v1/feeds fallback when /v1/livedata is unsupported

### DIFF
--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/auth.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/auth.py
@@ -14,9 +14,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
-import os
 import re
-import time
 
 import aiohttp
 
@@ -127,11 +125,10 @@ def build_digest_header(
 
     # For VSN300, we typically don't use qop, but handle it if present
     if qop:
-        nc = "00000001"
-        # Generate cnonce like stdlib: H(nonce:time:random)
-
-        cnonce_input = f"{nonce}:{time.time()}:{os.urandom(8).hex()}"
-        cnonce = hashlib.md5(cnonce_input.encode()).hexdigest()[:16]  # noqa: S324
+        # VSN300 firmware (auth-filter.js) validates against these EXACT constants.
+        # Any other nc/cnonce -> HTTP 401. See issue #68.
+        nc = "00000002"
+        cnonce = "ddf4bfcaf87acba9"
         response = calculate_digest_response(
             username, password, realm, nonce, method, uri, qop, nc, cnonce
         )

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/auth.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/auth.py
@@ -418,7 +418,7 @@ async def detect_vsn_model(
                 )
 
                 try:
-                    status_data = await response.json()
+                    status_data = await response.json(encoding="latin-1", content_type=None)
                     model = _detect_model_from_status(status_data)
                 except Exception as parse_err:
                     _LOGGER.error(

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/client.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/client.py
@@ -169,7 +169,7 @@ class ABBFimerVSNRestClient:
                 )
 
                 if response.status == 200:
-                    data = await response.json()
+                    data = await response.json(encoding="latin-1", content_type=None)
                     # Count total points across all devices
                     total_points = sum(
                         len(device_data.get("points", [])) for device_data in data.values()

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/client.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/client.py
@@ -8,8 +8,9 @@ from typing import Any
 import aiohttp
 
 from .auth import detect_vsn_model, get_vsn300_digest_header, get_vsn700_basic_auth
-from .constants import ENDPOINT_LIVEDATA
+from .constants import ENDPOINT_LIVEDATA, ENDPOINT_STATUS
 from .exceptions import VSNAuthenticationError, VSNConnectionError
+from .feeds import fetch_feeds_as_livedata
 from .normalizer import VSNDataNormalizer
 from .utils import check_socket_connection
 
@@ -55,6 +56,10 @@ class ABBFimerVSNRestClient:
         # Maps livedata device keys to device_type for injection before normalization.
         # Built lazily on first poll from _discovered_devices, invalidated on update.
         self._device_type_map: dict[str, str] | None = None
+        # VSN300 /v1/feeds fallback: sticky flag so a dead /v1/livedata is not
+        # re-probed every poll; cached /v1/status used to enumerate devices.
+        self._use_feeds = False
+        self._status_data: dict[str, Any] | None = None
 
     async def connect(self) -> str:
         """Connect and detect VSN model.
@@ -100,10 +105,55 @@ class ABBFimerVSNRestClient:
             len(devices),
         )
 
+    async def _fetch_status_data(self) -> dict[str, Any]:
+        """Fetch and cache /v1/status (used to enumerate devices for feeds fallback)."""
+        if self._status_data is not None:
+            return self._status_data
+        uri = ENDPOINT_STATUS
+        url = f"{self.base_url}{uri}"
+        headers: dict[str, str] = {}
+        if self.requires_auth and self.vsn_model == "VSN300":
+            digest_value = await get_vsn300_digest_header(
+                self.session,
+                self.base_url,
+                self.username,
+                self.password,
+                uri,
+                "GET",
+                self.timeout,
+            )
+            headers = {"Authorization": f"X-Digest {digest_value}"}
+        async with self.session.get(
+            url, headers=headers, timeout=aiohttp.ClientTimeout(total=self.timeout)
+        ) as response:
+            if response.status != 200:
+                raise VSNConnectionError(
+                    f"Status request failed: HTTP {response.status}"
+                )
+            self._status_data = await response.json(
+                encoding="latin-1", content_type=None
+            )
+        return self._status_data
+
+    async def _feeds_livedata(self) -> dict[str, Any]:
+        """Fetch livedata via the /v1/feeds fallback (VSN300 with dead /v1/livedata)."""
+        status_data = await self._fetch_status_data()
+        return await fetch_feeds_as_livedata(
+            self.session,
+            self.base_url,
+            status_data,
+            self.username,
+            self.password,
+            self.timeout,
+            self.requires_auth,
+        )
+
     async def get_livedata(self) -> dict[str, Any]:
         """Fetch livedata from VSN device.
 
-        Both VSN300 and VSN700 use /v1/livedata endpoint.
+        Both VSN300 and VSN700 use /v1/livedata endpoint. On VSN300 firmware
+        where /v1/livedata drops the connection, this transparently falls back
+        to the /v1/feeds datastreams adapter (sticky after the first failure).
 
         Returns:
             Raw livedata response from VSN
@@ -114,6 +164,10 @@ class ABBFimerVSNRestClient:
         """
         if not self.vsn_model:
             await self.connect()
+
+        # Sticky: once /v1/livedata proved dead, go straight to /v1/feeds.
+        if self._use_feeds:
+            return await self._feeds_livedata()
 
         # Check socket connection before HTTP request
         await check_socket_connection(self.base_url, timeout=5)
@@ -216,6 +270,15 @@ class ABBFimerVSNRestClient:
                 err,
                 type(err).__name__,
             )
+            # VSN300 firmware (e.g. 2.0.0) drops the TCP connection on /v1/livedata.
+            # Fall back to /v1/feeds and remember it so we skip the dead endpoint.
+            if self.vsn_model == "VSN300":
+                _LOGGER.info(
+                    "[Client] /v1/livedata unavailable (%s); using /v1/feeds fallback",
+                    type(err).__name__,
+                )
+                self._use_feeds = True
+                return await self._feeds_livedata()
             raise VSNConnectionError(f"Livedata request error: {err}") from err
 
     async def get_normalized_data(self) -> dict[str, Any]:

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/constants.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/constants.py
@@ -4,6 +4,9 @@
 ENDPOINT_STATUS = "/v1/status"
 ENDPOINT_LIVEDATA = "/v1/livedata"
 ENDPOINT_FEEDS = "/v1/feeds"
+# Per-device datastreams (VSN300 fallback when /v1/livedata is dead).
+# Format: /v1/feeds/ser4:<invID>/datastreams
+ENDPOINT_FEED_DATASTREAMS = "/v1/feeds/{feed_key}/datastreams"
 
 # Aurora protocol epoch offset (Jan 1, 2000 00:00:00 UTC)
 # The Aurora protocol uses a custom epoch instead of Unix epoch (Jan 1, 1970)

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/discovery.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/discovery.py
@@ -205,7 +205,7 @@ async def _fetch_status(
             )
 
             if response.status == 200:
-                data = await response.json()
+                data = await response.json(encoding="latin-1", content_type=None)
                 _LOGGER.debug(
                     "[Discovery Status] Successfully fetched status data (%d bytes)",
                     len(str(data)),
@@ -297,7 +297,7 @@ async def _fetch_livedata(
             )
 
             if response.status == 200:
-                data = await response.json()
+                data = await response.json(encoding="latin-1", content_type=None)
                 _LOGGER.debug(
                     "[Discovery Livedata] Successfully fetched livedata: %d devices, %d bytes",
                     len(data),

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/discovery.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/discovery.py
@@ -16,6 +16,7 @@ import aiohttp
 from .auth import detect_vsn_model, get_vsn300_digest_header, get_vsn700_basic_auth
 from .constants import ENDPOINT_LIVEDATA, ENDPOINT_STATUS
 from .exceptions import VSNConnectionError
+from .feeds import fetch_feeds_as_livedata
 from .utils import check_socket_connection
 
 _LOGGER = logging.getLogger(__name__)
@@ -107,9 +108,16 @@ async def discover_vsn_device(
         session, base_url, vsn_model, username, password, timeout, requires_auth
     )
 
-    # Step 3: Fetch livedata
+    # Step 3: Fetch livedata (pass status_data for the VSN300 /v1/feeds fallback)
     livedata = await _fetch_livedata(
-        session, base_url, vsn_model, username, password, timeout, requires_auth
+        session,
+        base_url,
+        vsn_model,
+        username,
+        password,
+        timeout,
+        requires_auth,
+        status_data,
     )
 
     # Step 4: Extract logger information from status
@@ -236,6 +244,7 @@ async def _fetch_livedata(
     password: str,
     timeout: int,
     requires_auth: bool = True,
+    status_data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Fetch livedata endpoint.
 
@@ -247,6 +256,8 @@ async def _fetch_livedata(
         password: Authentication password
         timeout: Request timeout in seconds
         requires_auth: Whether authentication is required
+        status_data: Parsed /v1/status, used to enumerate devices for the
+            VSN300 /v1/feeds fallback when /v1/livedata is unavailable
 
     Returns:
         Livedata dictionary
@@ -318,6 +329,23 @@ async def _fetch_livedata(
             err,
             type(err).__name__,
         )
+        # VSN300 firmware (e.g. 2.0.0) drops the TCP connection on /v1/livedata.
+        # Fall back to /v1/feeds datastreams, which returns the same point keys.
+        if vsn_model == "VSN300" and status_data is not None:
+            _LOGGER.info(
+                "[Discovery Livedata] /v1/livedata unavailable (%s); "
+                "falling back to /v1/feeds",
+                type(err).__name__,
+            )
+            return await fetch_feeds_as_livedata(
+                session,
+                base_url,
+                status_data,
+                username,
+                password,
+                timeout,
+                requires_auth,
+            )
         raise VSNConnectionError(f"Failed to fetch livedata: {err}") from err
 
 

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/feeds.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/feeds.py
@@ -14,6 +14,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import aiohttp
+
+from .auth import get_vsn300_digest_header
+from .constants import ENDPOINT_FEED_DATASTREAMS
+from .exceptions import VSNConnectionError
+
 _LOGGER = logging.getLogger(__name__)
 
 FEED_KEY_PREFIX = "ser4:"
@@ -102,3 +108,78 @@ def reshape_datastreams(
             value = value * scale
         points.append({"name": point_name, "value": value})
     return {feed_key: {"device_type": device_type, "points": points}}
+
+
+async def fetch_feeds_as_livedata(
+    session: aiohttp.ClientSession,
+    base_url: str,
+    status_data: dict[str, Any],
+    username: str,
+    password: str,
+    timeout: int,
+    requires_auth: bool = True,
+) -> dict[str, Any]:
+    """Fetch per-device datastreams and return them in livedata shape.
+
+    Fallback for VSN300 firmware where /v1/livedata drops the connection.
+    Enumerates inverters from /v1/status (device.invID) and reads each one's
+    /v1/feeds/ser4:<invID>/datastreams, reshaping into the livedata-shaped dict
+    the normalizer consumes.
+
+    Args:
+        session: aiohttp client session.
+        base_url: Base URL of the VSN300.
+        status_data: The parsed /v1/status JSON (device enumeration source).
+        username: Digest username.
+        password: Digest password.
+        timeout: Per-request timeout in seconds.
+        requires_auth: Whether to send X-Digest auth (VSN300: True).
+
+    Returns:
+        ``{device_id: {device_type, points: [{name, value}, ...]}}`` merged
+        across all enumerated inverters. Empty dict when no devices found.
+
+    Raises:
+        VSNConnectionError: On non-200 response or transport error.
+
+    """
+    base_url = base_url.rstrip("/")
+    devices = parse_status_devices(status_data)
+    if not devices:
+        _LOGGER.warning("[Feeds Fallback] No inverter devices found in status data")
+        return {}
+
+    merged: dict[str, Any] = {}
+    for device in devices:
+        feed_key = device["feed_key"]
+        uri = ENDPOINT_FEED_DATASTREAMS.format(feed_key=feed_key)
+        url = f"{base_url}{uri}"
+
+        headers: dict[str, str] = {}
+        if requires_auth:
+            digest_value = await get_vsn300_digest_header(
+                session, base_url, username, password, uri, "GET", timeout
+            )
+            headers = {"Authorization": f"X-Digest {digest_value}"}
+
+        _LOGGER.debug("[Feeds Fallback] Fetching datastreams: url=%s", url)
+        try:
+            async with session.get(
+                url, headers=headers, timeout=aiohttp.ClientTimeout(total=timeout)
+            ) as response:
+                if response.status != 200:
+                    raise VSNConnectionError(
+                        f"Feeds datastreams request failed: HTTP {response.status}"
+                    )
+                data = await response.json(encoding="latin-1", content_type=None)
+        except aiohttp.ClientError as err:
+            raise VSNConnectionError(
+                f"Feeds datastreams request error: {err}"
+            ) from err
+
+        merged.update(reshape_datastreams(data, feed_key, "inverter"))
+
+    _LOGGER.info(
+        "[Feeds Fallback] Assembled %d device(s) from /v1/feeds", len(merged)
+    )
+    return merged

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/feeds.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/feeds.py
@@ -1,0 +1,53 @@
+"""/v1/feeds fallback adapter for VSN300 firmware where /v1/livedata is dead.
+
+Some VSN300 firmware (e.g. 2.0.0) drops the TCP connection on every /v1/livedata
+request. The web UI reads live data from /v1/feeds/ser4:<invID>/datastreams
+instead. This module fetches that endpoint and reshapes it into the same
+{device_id: {device_type, points: [{name, value}]}} structure the normalizer
+already consumes from livedata, so no normalizer changes are needed.
+
+See issue #68 item 3.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+FEED_KEY_PREFIX = "ser4:"
+
+
+def build_feed_key(inv_id: str) -> str:
+    """Build the /v1/feeds device key from an inverter serial (device.invID)."""
+    return f"{FEED_KEY_PREFIX}{inv_id}"
+
+
+def parse_status_devices(status_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Enumerate real inverter devices from /v1/status.
+
+    Bare /v1/feeds is empty on this firmware, so devices are enumerated from the
+    status endpoint's flattened dotted keys (``keys["device.invID"]``) and
+    addressed as ``ser4:<invID>``.
+
+    Args:
+        status_data: The parsed /v1/status JSON.
+
+    Returns:
+        One dict per real inverter, each with ``feed_key``, ``inv_id``,
+        ``device_model`` and ``ac_type``. Empty list when no ``device.invID``.
+
+    """
+    keys = status_data.get("keys", {})
+    inv_id = keys.get("device.invID", {}).get("value")
+    if not inv_id:
+        return []
+    return [
+        {
+            "feed_key": build_feed_key(inv_id),
+            "inv_id": inv_id,
+            "device_model": keys.get("device.modelDesc", {}).get("value"),
+            "ac_type": keys.get("device.ACType", {}).get("value"),
+        }
+    ]

--- a/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/feeds.py
+++ b/custom_components/abb_fimer_pvi_vsn_rest/abb_fimer_vsn_rest_client/feeds.py
@@ -18,6 +18,25 @@ _LOGGER = logging.getLogger(__name__)
 
 FEED_KEY_PREFIX = "ser4:"
 
+# The /v1/feeds endpoint reports values in display units (e.g. m101_1_W in kW,
+# m101_1_WH in kWh), but the normalizer expects the raw SunSpec magnitudes that
+# /v1/livedata delivers (W, Wh). Scale by the SI prefix of the datastream's
+# "units" field so feeds-sourced values match the livedata scale.
+# Verified on hardware: feeds m101_1_W=1.599 kW == Modbus 1587 W;
+# feeds m101_1_WH=35585.96 kWh == Modbus 35586016 Wh.
+_SI_PREFIX_SCALE = {"k": 1000.0, "M": 1_000_000.0, "G": 1_000_000_000.0}
+
+
+def _scale_for_units(units: str | None) -> float:
+    """Return the multiplier that converts a display unit to its base SI unit.
+
+    Only power/energy magnitudes carry SI prefixes here (kW, kWh, MWh). Base
+    units (A, V, Hz, W, Wh) and missing/unknown units pass through unscaled.
+    """
+    if not units or len(units) < 2:
+        return 1.0
+    return _SI_PREFIX_SCALE.get(units[0], 1.0)
+
 
 def build_feed_key(inv_id: str) -> str:
     """Build the /v1/feeds device key from an inverter serial (device.invID)."""
@@ -51,3 +70,35 @@ def parse_status_devices(status_data: dict[str, Any]) -> list[dict[str, Any]]:
             "ac_type": keys.get("device.ACType", {}).get("value"),
         }
     ]
+
+
+def reshape_datastreams(
+    feeds_response: dict[str, Any], feed_key: str, device_type: str
+) -> dict[str, Any]:
+    """Reshape a /v1/feeds datastreams response into livedata shape.
+
+    Args:
+        feeds_response: The parsed /v1/feeds/<feed_key>/datastreams JSON.
+        feed_key: The device key (e.g. ``ser4:<invID>``) to extract.
+        device_type: The device type label to stamp on the output.
+
+    Returns:
+        ``{feed_key: {"device_type": ..., "points": [{"name", "value"}, ...]}}``.
+        Uses the newest sample (``data[0]``); skips empty datastreams; scales
+        display units (kW/kWh/MWh) to base SI units (W/Wh) so values match the
+        magnitudes the normalizer expects from /v1/livedata.
+
+    """
+    feed = feeds_response.get("feeds", {}).get(feed_key, {})
+    datastreams = feed.get("datastreams", {})
+    points: list[dict[str, Any]] = []
+    for point_name, stream in datastreams.items():
+        data = stream.get("data") or []
+        if not data:
+            continue
+        value = data[0].get("value")
+        scale = _scale_for_units(stream.get("units"))
+        if value is not None and scale != 1.0:
+            value = value * scale
+        points.append({"name": point_name, "value": value})
+    return {feed_key: {"device_type": device_type, "points": points}}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -175,6 +175,23 @@ class TestBuildDigestHeader:
 
         assert 'opaque="xyz789"' in result
 
+    def test_build_header_uses_vsn300_firmware_constants(self) -> None:
+        """VSN300 firmware only accepts the hardcoded nc/cnonce constants."""
+        challenge_params = {
+            "realm": "registered_user@power-one.com",
+            "nonce": "abc123",
+            "qop": "auth",
+        }
+        result = build_digest_header(
+            username="guest",
+            password="password",  # noqa: S106
+            challenge_params=challenge_params,
+            method="GET",
+            uri="/v1/status",
+        )
+        assert "nc=00000002" in result
+        assert 'cnonce="ddf4bfcaf87acba9"' in result
+
 
 class TestGetVSN700BasicAuth:
     """Tests for get_vsn700_basic_auth function."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
+from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client import client as client_mod
 from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.client import (
     ABBFimerVSNRestClient,
 )
@@ -688,3 +689,75 @@ async def test_get_livedata_decodes_latin1_body() -> None:
     ):
         data = await client.get_livedata()
     assert data == payload
+
+
+async def test_get_livedata_falls_back_to_feeds_and_sticks() -> None:
+    """VSN300 client: dead livedata -> feeds fallback, and remembers it."""
+    feeds_shaped = {
+        "ser4:010261-3G97-1021": {
+            "device_type": "inverter",
+            "points": [{"name": "m101_1_W", "value": 1599.0}],
+        }
+    }
+
+    # livedata GET -> disconnect
+    live_ctx = MagicMock()
+    live_ctx.__aenter__ = AsyncMock(side_effect=aiohttp.ServerDisconnectedError("x"))
+    live_ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=live_ctx)
+
+    client = ABBFimerVSNRestClient(
+        session=session,
+        base_url="http://host",
+        vsn_model="VSN300",
+        requires_auth=True,
+    )
+
+    with (
+        patch.object(client_mod, "check_socket_connection", new=AsyncMock()),
+        patch.object(client_mod, "get_vsn300_digest_header", new=AsyncMock(return_value="h")),
+        patch.object(
+            client, "_fetch_status_data", new=AsyncMock(return_value={"keys": {}})
+        ),
+        patch.object(
+            client_mod, "fetch_feeds_as_livedata", new=AsyncMock(return_value=feeds_shaped)
+        ) as mock_feeds,
+    ):
+        first = await client.get_livedata()
+        assert first == feeds_shaped
+        assert client._use_feeds is True
+        # Second call must go straight to feeds without another livedata GET.
+        session.get.reset_mock()
+        second = await client.get_livedata()
+        assert second == feeds_shaped
+        session.get.assert_not_called()  # sticky: /v1/livedata not re-probed
+
+    assert mock_feeds.await_count == 2
+
+
+async def test_get_livedata_vsn700_does_not_fall_back() -> None:
+    """VSN700 must NOT use the feeds fallback; a disconnect re-raises."""
+    live_ctx = MagicMock()
+    live_ctx.__aenter__ = AsyncMock(side_effect=aiohttp.ServerDisconnectedError("x"))
+    live_ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=live_ctx)
+
+    client = ABBFimerVSNRestClient(
+        session=session,
+        base_url="http://host",
+        vsn_model="VSN700",
+        requires_auth=False,
+    )
+
+    with (
+        patch.object(client_mod, "check_socket_connection", new=AsyncMock()),
+        patch.object(
+            client_mod, "fetch_feeds_as_livedata", new=AsyncMock()
+        ) as mock_feeds,
+        pytest.raises(VSNConnectionError),
+    ):
+        await client.get_livedata()
+    assert client._use_feeds is False
+    mock_feeds.assert_not_awaited()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -652,3 +652,39 @@ class TestDeviceTypeInjection:
         client._ensure_device_type_map()
 
         assert client._device_type_map == {}
+
+
+async def test_get_livedata_decodes_latin1_body() -> None:
+    """VSN serves ISO-8859-1 JSON with application/json; must not UnicodeDecodeError."""
+    from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.client import (
+        ABBFimerVSNRestClient,
+    )
+
+    # 0xB4 is the acute-accent byte that crashes utf-8 json()
+    payload = {"ser4:X": {"points": [{"name": "lbl", "value": "caf´"}]}}
+
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+
+    async def _json(encoding=None, content_type=None):
+        assert encoding == "latin-1"
+        assert content_type is None
+        return payload
+
+    mock_resp.json = _json
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    session = MagicMock()
+    session.get = MagicMock(return_value=mock_ctx)
+
+    client = ABBFimerVSNRestClient(
+        session=session, base_url="http://host", vsn_model="VSN700", requires_auth=False
+    )
+    with patch(
+        "custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.client.check_socket_connection",
+        new=AsyncMock(),
+    ):
+        data = await client.get_livedata()
+    assert data == payload

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
+from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client import discovery as disc
 from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.discovery import (
     DiscoveredDevice,
     DiscoveryResult,
@@ -869,3 +870,78 @@ class TestExtractLoggerInfoEdgeCases:
         assert info["logger_model"] == "WIFI LOGGER CARD"
         assert info["firmware_version"] == "1.9.2"
         assert info["hostname"] == "ABB-077909-3G82-3112.local"
+
+
+async def test_fetch_livedata_falls_back_to_feeds_on_disconnect() -> None:
+    """VSN300: a dead /v1/livedata must fall back to the feeds adapter."""
+    status_data = {
+        "keys": {
+            "device.invID": {"value": "010261-3G97-1021"},
+            "device.modelDesc": {"value": "PVI-3.6-OUTD"},
+            "device.ACType": {"value": "Single"},
+        }
+    }
+    feeds_shaped = {
+        "ser4:010261-3G97-1021": {
+            "device_type": "inverter",
+            "points": [{"name": "m101_1_W", "value": 1599.0}],
+        }
+    }
+
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(
+        side_effect=aiohttp.ServerDisconnectedError("Server disconnected")
+    )
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=mock_ctx)
+
+    with (
+        patch.object(disc, "check_socket_connection", new=AsyncMock()),
+        patch.object(disc, "get_vsn300_digest_header", new=AsyncMock(return_value="hdr")),
+        patch.object(
+            disc, "fetch_feeds_as_livedata", new=AsyncMock(return_value=feeds_shaped)
+        ) as mock_feeds,
+    ):
+        result = await disc._fetch_livedata(
+            session=session,
+            base_url="http://host",
+            vsn_model="VSN300",
+            username="guest",
+            password="pw",  # noqa: S106
+            timeout=10,
+            requires_auth=True,
+            status_data=status_data,
+        )
+
+    assert result == feeds_shaped
+    mock_feeds.assert_awaited_once()
+
+
+async def test_fetch_livedata_no_fallback_without_status_data() -> None:
+    """VSN300 without status_data must NOT fall back; it re-raises."""
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(
+        side_effect=aiohttp.ServerDisconnectedError("x")
+    )
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=mock_ctx)
+
+    with (
+        patch.object(disc, "check_socket_connection", new=AsyncMock()),
+        patch.object(disc, "get_vsn300_digest_header", new=AsyncMock(return_value="hdr")),
+        patch.object(disc, "fetch_feeds_as_livedata", new=AsyncMock()) as mock_feeds,
+        pytest.raises(VSNConnectionError),
+    ):
+        await disc._fetch_livedata(
+            session=session,
+            base_url="http://host",
+            vsn_model="VSN300",
+            username="guest",
+            password="pw",  # noqa: S106
+            timeout=10,
+            requires_auth=True,
+            status_data=None,
+        )
+    mock_feeds.assert_not_awaited()

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -103,3 +103,78 @@ def test_reshape_datastreams_megawatt_scale() -> None:
     assert points["big_WH"] == 2_500_000.0
     assert points["plain_W"] == 900.0  # already base unit, unchanged
     assert points["nounits"] == 42.0  # no units field -> passthrough
+
+
+async def test_fetch_feeds_as_livedata_merges_devices() -> None:
+    """End-to-end adapter: enumerate from status, fetch datastreams, reshape+scale."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client import (
+        feeds as feeds_mod,
+    )
+
+    status = {
+        "keys": {
+            "device.invID": {"value": "010261-3G97-1021"},
+            "device.modelDesc": {"value": "PVI-3.6-OUTD"},
+            "device.ACType": {"value": "Single"},
+        }
+    }
+    datastreams_json = {
+        "feeds": {
+            "ser4:010261-3G97-1021": {
+                "datastreams": {
+                    "m101_1_W": {"data": [{"value": 1.599, "timestamp": "t"}], "units": "kW"},
+                }
+            }
+        }
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.json = AsyncMock(return_value=datastreams_json)
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=mock_ctx)
+
+    with patch.object(
+        feeds_mod, "get_vsn300_digest_header", new=AsyncMock(return_value="hdr")
+    ):
+        result = await feeds_mod.fetch_feeds_as_livedata(
+            session=session,
+            base_url="http://host",
+            status_data=status,
+            username="guest",
+            password="pw",  # noqa: S106
+            timeout=10,
+            requires_auth=True,
+        )
+
+    assert "ser4:010261-3G97-1021" in result
+    pts = {p["name"]: p["value"] for p in result["ser4:010261-3G97-1021"]["points"]}
+    assert pts == {"m101_1_W": 1599.0}  # kW -> W scaling applied
+    assert result["ser4:010261-3G97-1021"]["device_type"] == "inverter"
+
+
+async def test_fetch_feeds_as_livedata_no_devices_returns_empty() -> None:
+    """No inverter in status -> empty dict, no HTTP calls."""
+    from unittest.mock import MagicMock
+
+    from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client import (
+        feeds as feeds_mod,
+    )
+
+    session = MagicMock()
+    result = await feeds_mod.fetch_feeds_as_livedata(
+        session=session,
+        base_url="http://host",
+        status_data={"keys": {}},
+        username="guest",
+        password="pw",  # noqa: S106
+        timeout=10,
+        requires_auth=True,
+    )
+    assert result == {}
+    session.get.assert_not_called()

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -34,3 +34,72 @@ def test_parse_status_devices_single_inverter() -> None:
 
 def test_parse_status_devices_no_inverter() -> None:
     assert parse_status_devices({"keys": {}}) == []
+
+
+def test_reshape_datastreams_takes_newest_sample_and_scales_units() -> None:
+    """Newest sample = data[0]; feeds display units (kW/kWh) scale to SunSpec W/Wh.
+
+    The /v1/feeds endpoint reports m101_1_W in kW and m101_1_WH in kWh, but the
+    normalizer expects raw SunSpec magnitudes (W, Wh) as /v1/livedata delivers.
+    Verified against hardware: feeds m101_1_W=1.599 kW == Modbus 1587 W.
+    """
+    from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.feeds import (
+        reshape_datastreams,
+    )
+
+    feeds_response = {
+        "feeds": {
+            "ser4:010261-3G97-1021": {
+                "datastreams": {
+                    "m101_1_W": {
+                        "data": [
+                            {"value": 1.599, "timestamp": "2026-07-30T08:50:16"},
+                            {"value": 1.500, "timestamp": "2026-07-30T08:45:16"},
+                        ],
+                        "units": "kW",
+                    },
+                    "m101_1_WH": {
+                        "data": [{"value": 35585.96, "timestamp": "2026-07-30T08:50:16"}],
+                        "units": "kWh",
+                    },
+                    "m101_1_A": {
+                        "data": [{"value": 6.55, "timestamp": "2026-07-30T08:50:16"}],
+                        "units": "A",
+                    },
+                    "m101_1_empty": {"data": [], "units": "A"},
+                }
+            }
+        }
+    }
+    result = reshape_datastreams(feeds_response, "ser4:010261-3G97-1021", "inverter")
+    assert result["ser4:010261-3G97-1021"]["device_type"] == "inverter"
+    points = {p["name"]: p["value"] for p in result["ser4:010261-3G97-1021"]["points"]}
+    # kW -> W (*1000), kWh -> Wh (*1000), A unchanged, empty stream skipped.
+    assert points["m101_1_W"] == 1599.0
+    assert points["m101_1_WH"] == 35585960.0
+    assert points["m101_1_A"] == 6.55
+    assert "m101_1_empty" not in points
+
+
+def test_reshape_datastreams_megawatt_scale() -> None:
+    """MW/MWh display units scale by 1e6."""
+    from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.feeds import (
+        reshape_datastreams,
+    )
+
+    feeds_response = {
+        "feeds": {
+            "ser4:X": {
+                "datastreams": {
+                    "big_WH": {"data": [{"value": 2.5, "timestamp": "t"}], "units": "MWh"},
+                    "plain_W": {"data": [{"value": 900.0, "timestamp": "t"}], "units": "W"},
+                    "nounits": {"data": [{"value": 42.0, "timestamp": "t"}]},
+                }
+            }
+        }
+    }
+    result = reshape_datastreams(feeds_response, "ser4:X", "inverter")
+    points = {p["name"]: p["value"] for p in result["ser4:X"]["points"]}
+    assert points["big_WH"] == 2_500_000.0
+    assert points["plain_W"] == 900.0  # already base unit, unchanged
+    assert points["nounits"] == 42.0  # no units field -> passthrough

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1,0 +1,36 @@
+"""Tests for the /v1/feeds fallback adapter."""
+
+from __future__ import annotations
+
+from custom_components.abb_fimer_pvi_vsn_rest.abb_fimer_vsn_rest_client.feeds import (
+    build_feed_key,
+    parse_status_devices,
+)
+
+
+def test_build_feed_key() -> None:
+    assert build_feed_key("010261-3G97-1021") == "ser4:010261-3G97-1021"
+
+
+def test_parse_status_devices_single_inverter() -> None:
+    status = {
+        "keys": {
+            "device.invID": {"value": "010261-3G97-1021"},
+            "device.modelDesc": {"value": "PVI-3.6-OUTD"},
+            "device.ACType": {"value": "Single"},
+            "logger.sn": {"value": "124437-3N16-2721"},
+        }
+    }
+    devices = parse_status_devices(status)
+    assert devices == [
+        {
+            "feed_key": "ser4:010261-3G97-1021",
+            "inv_id": "010261-3G97-1021",
+            "device_model": "PVI-3.6-OUTD",
+            "ac_type": "Single",
+        }
+    ]
+
+
+def test_parse_status_devices_no_inverter() -> None:
+    assert parse_status_devices({"keys": {}}) == []


### PR DESCRIPTION
Fixes item **3** of #68.

> **⚠️ Stacked on #69 — please review/merge that first.** This branch is built on top of #69 (`fix/vsn300-digest-constants-and-latin1-json`); the feeds fallback depends on the latin-1 decoding and digest constants from that PR. Because it's a cross-fork PR, GitHub won't let me target #69's branch as the base, so this targets `main` directly. **Until #69 merges, the diff below also includes #69's 2 commits** (the last 5 commits `ac6bf02…a27a765` are the ones unique to this PR). Once #69 lands in `main`, this diff cleans up to just the feeds changes automatically.

## Problem
On VSN300 firmware 2.0.0, `/v1/livedata` drops the TCP connection on every request (`ServerDisconnectedError`), so discovery and every poll fail even after the auth fixes in #69. The web UI itself never uses `/v1/livedata` — it reads `/v1/feeds/ser4:<invID>/datastreams`.

## Fix
A source-agnostic adapter (`feeds.py`) that:
- enumerates inverters from `/v1/status` (`device.invID` → `ser4:<invID>`; bare `/v1/feeds` is empty on this firmware),
- fetches `/v1/feeds/ser4:<invID>/datastreams` (one call/device, values inline, newest sample = `data[0]`),
- **scales feeds display units to SunSpec magnitudes** — feeds reports `m101_1_W` in **kW** and `m101_1_WH` in **kWh**, but the normalizer expects raw W/Wh as `/v1/livedata` delivers; the adapter scales by the SI prefix of each datastream's `units` field (`k`→×1000, `M`→×1e6),
- reshapes into the exact `{device_id: {device_type, points:[{name,value}]}}` structure the normalizer already consumes. **No normalizer changes.**

Wired as a **fallback only**, **VSN300 only**, triggered on livedata connection failure — in both discovery and the runtime client (with a sticky `_use_feeds` flag so the dead endpoint isn't re-probed each poll). Healthy-livedata VSN300 and all VSN700 paths are unchanged (covered by a negative test).

## Validation against real hardware
Verified end-to-end against a live VSN300 (firmware 2.0.0, `PVI-3.6-OUTD`, single-phase, inverter `010261-3G97-1021`): `connect()` → `/v1/livedata` disconnect → sticky `/v1/feeds` fallback → reshape+scale → normalizer, cross-checked against the same inverter's Modbus readings.

| Measure | Feeds → normalized | Live Modbus | Delta |
|---|---|---|---|
| AC power (`Power AC`) | **1737.9 W** | 1817 W | ~79 W (~4%, morning ramp, samples secs apart) |
| Lifetime energy | 35,586,186 Wh | 35,586,360 Wh | 174 Wh |
| Day energy | 1.783 kWh | — | plausible, monotonic |

Normalized AC power comes out in **Watts (1737.9), not kW (1.74)** — the unit reconciliation is correct through the real normalizer. 27 inverter points normalized in total.

## Tests
New `tests/test_feeds.py` (adapter: enumeration, reshape, kW→W and MW→W scaling, async fetch, empty-devices); discovery + client fallback tests using a mocked `ServerDisconnectedError`, plus VSN700/no-status_data negative tests proving the guards. Full suite green (pre-existing `test_config_flow` fixture failures are unrelated to this change).